### PR TITLE
Quelques changements et clarifications.

### DIFF
--- a/platform.swagger.yml
+++ b/platform.swagger.yml
@@ -115,17 +115,17 @@ definitions:
           - terminated # if the instance has been terminated
       adminName:
         type: string
-        description: name of the instance admin user
+        description: name of the instance admin user (may be in sync with the running instance, or as given in the request)
       adminEmail:
         type: string
         format: email
-        description: email of the instance admin user
+        description: email of the instance admin user (may be in sync with the running instance, or as given in the request)
       adminPhone:
         type: string
-        description: phone number of the instance admin user
+        description: phone number of the instance admin user (may be in sync with the running instance, or as given in the request)
       adminOrganizationName:
         type: string
-        description: name of the organization of the admin user
+        description: name of the organization of the admin user (may be in sync with the running instance, or as given in the request)
       metadata:
         type: object
         additionalProperties: {}

--- a/provider.swagger.yml
+++ b/provider.swagger.yml
@@ -146,16 +146,17 @@ definitions:
         description: the full url to access the consultation instance
       name:
         type: string
-        description: name of the instance (as it was provided by the client, even if it gets altered later in the instance lifecycle)
+        description: name of the instance
       adminName:
         type: string
-        description: name of the instance admin user (as it was provided by the client, even if it gets altered later in the instance lifecycle)
+        description: name of the instance admin user
       adminEmail:
         type: string
         format: email
-        description: email of the instance admin user (as it was provided by the client, even if it gets altered later in the instance lifecycle)
+        description: email of the instance admin user
       requestIdentifier:
         type: string
+        required: false
         description: the instance request identifier (generated and provided by the client)
       status:
         type: string

--- a/provider.swagger.yml
+++ b/provider.swagger.yml
@@ -121,8 +121,14 @@ definitions:
     required:
       - message
     properties:
+      code:
+        type: integer
+        required: false
+        description: >
+          An agreed upon error code. example: 100 (slug conflict.)
       message:
         type: string
+        example: "slug exists"
       errors:
         type: object
         additionalProperties: {}

--- a/provider.swagger.yml
+++ b/provider.swagger.yml
@@ -103,7 +103,6 @@ paths:
           description: id of the instance
           required: true
           type: string
-          format: uuid
       security:
         -
           api_key: []

--- a/provider.swagger.yml
+++ b/provider.swagger.yml
@@ -77,7 +77,15 @@ paths:
             $ref: "#/definitions/Instance"
         400:
           description: >
-            When the request tries to creata an instance for which the slug is already in use, the response should have a HTTP 400 status code, except if the instance status is "`failed`". In that specific case, the instance status will be changed to "`requested`" and the response should use the HTTP 202 status code.
+            The request cannot be executed, for reasons due to the request that will normally preclude a retry.
+            Examples: slug too long.
+            Special case: If the slug already exists, the answer should be a 400 UNLESS the instance is in a failed state (AND it can be retried.)
+            In that case, retry creating the instance with the same Location as previously, and return a 201, 202 or 500 appropriately.
+          schema:
+            $ref: "#/definitions/Error"
+        500:
+          description: >
+            Internal error. Retrying may be possible.
           schema:
             $ref: "#/definitions/Error"
         default:


### PR DESCRIPTION
J'ai séparé les propositions en commits pour qu'il soit plus facile de les envisager séparément. 
Entre autre je propose des codes d'erreur standardisés, pour que le cas très spécial de la slug utilisée soit plus facile à distinguer que par comparaison de chaîne. 
J'aimerais m'éviter de mémoriser les paramètres de la requête, j'ai donc éliminé cette contrainte de la description du contenu de l'instance.
